### PR TITLE
use thiserror instead of anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,13 +239,13 @@ name = "jupiter-amm-interface"
 version = "0.6.1"
 dependencies = [
  "ahash 0.8.12",
- "anyhow",
  "rust_decimal",
  "serde",
  "serde_json",
  "solana-account",
  "solana-clock",
  "solana-instruction",
+ "solana-program-error",
  "solana-pubkey",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ keywords = ["solana", "jupiter", "aggregator"]
 
 [dependencies]
 ahash = "0.8"
-anyhow = "1"
 rust_decimal = "1.36.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 solana-account = { version = "3.4.0", features = ["serde"] }
 solana-clock = "3.0.0"
 solana-instruction = "3.1.0"
+solana-program-error = "3.0.0"
 solana-pubkey = "4.0.0"
 thiserror = "2.0.18"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,86 +139,26 @@ where
 }
 
 #[derive(Debug, Error)]
-pub enum AmmFromKeyedAccountError {
-    #[error(transparent)]
-    Io(#[from] io::Error),
-    #[error(transparent)]
-    Json(#[from] serde_json::Error),
-    #[error("{0}")]
-    Custom(String),
-}
-
-impl From<&str> for AmmFromKeyedAccountError {
-    fn from(value: &str) -> Self {
-        Self::Custom(value.to_string())
-    }
-}
-
-impl From<String> for AmmFromKeyedAccountError {
-    fn from(value: String) -> Self {
-        Self::Custom(value)
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum AmmUpdateError {
+pub enum AmmError {
     #[error(transparent)]
     AccountNotFound(#[from] AccountNotFoundError),
     #[error(transparent)]
     Io(#[from] io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
     #[error(transparent)]
     Program(#[from] ProgramError),
     #[error("{0}")]
     Custom(String),
 }
 
-impl From<&str> for AmmUpdateError {
+impl From<&str> for AmmError {
     fn from(value: &str) -> Self {
         Self::Custom(value.to_string())
     }
 }
 
-impl From<String> for AmmUpdateError {
-    fn from(value: String) -> Self {
-        Self::Custom(value)
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum AmmQuoteError {
-    #[error(transparent)]
-    Io(#[from] io::Error),
-    #[error("{0}")]
-    Custom(String),
-}
-
-impl From<&str> for AmmQuoteError {
-    fn from(value: &str) -> Self {
-        Self::Custom(value.to_string())
-    }
-}
-
-impl From<String> for AmmQuoteError {
-    fn from(value: String) -> Self {
-        Self::Custom(value)
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum AmmGetSwapAndAccountMetasError {
-    #[error(transparent)]
-    Io(#[from] io::Error),
-    #[error("{0}")]
-    Custom(String),
-}
-
-impl From<&str> for AmmGetSwapAndAccountMetasError {
-    fn from(value: &str) -> Self {
-        Self::Custom(value.to_string())
-    }
-}
-
-impl From<String> for AmmGetSwapAndAccountMetasError {
+impl From<String> for AmmError {
     fn from(value: String) -> Self {
         Self::Custom(value)
     }
@@ -229,7 +169,7 @@ pub trait Amm: Clone {
     fn from_keyed_account(
         keyed_account: &KeyedAccount,
         amm_context: &AmmContext,
-    ) -> Result<Self, AmmFromKeyedAccountError>
+    ) -> Result<Self, AmmError>
     where
         Self: Sized;
 
@@ -250,16 +190,16 @@ pub trait Amm: Clone {
 
     /// Picks necessary accounts to update it's internal state
     /// Heavy deserialization and precomputation caching should be done in this function
-    fn update(&mut self, account_provider: impl AccountProvider) -> Result<(), AmmUpdateError>;
+    fn update(&mut self, account_provider: impl AccountProvider) -> Result<(), AmmError>;
 
     /// Computes the expected token amounts and fees for a swap without executing it
-    fn quote(&self, quote_params: &QuoteParams) -> Result<Quote, AmmQuoteError>;
+    fn quote(&self, quote_params: &QuoteParams) -> Result<Quote, AmmError>;
 
     /// Indicates which Swap has to be performed along with all the necessary account metas
     fn get_swap_and_account_metas(
         &self,
         swap_params: &SwapParams,
-    ) -> Result<SwapAndAccountMetas, AmmGetSwapAndAccountMetasError>;
+    ) -> Result<SwapAndAccountMetas, AmmError>;
 
     /// Indicates if get_accounts_to_update might return a non constant vec
     fn has_dynamic_accounts(&self) -> bool {

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -219,7 +219,7 @@ pub enum CandidateSwap {
 
 #[derive(Debug, thiserror::Error)]
 #[error("Swap {0:?} is not a valid candidate swap")]
-pub struct InvalidCandidateSwapError(Swap);
+pub struct InvalidCandidateSwapError(pub Swap);
 
 impl TryInto<CandidateSwap> for Swap {
     type Error = InvalidCandidateSwapError;

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -1,5 +1,3 @@
-use anyhow::anyhow;
-
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Side {
     Bid,
@@ -219,8 +217,12 @@ pub enum CandidateSwap {
     },
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("Swap {0:?} is not a valid candidate swap")]
+pub struct InvalidCandidateSwapError(Swap);
+
 impl TryInto<CandidateSwap> for Swap {
-    type Error = anyhow::Error;
+    type Error = InvalidCandidateSwapError;
 
     fn try_into(self) -> Result<CandidateSwap, Self::Error> {
         let candidate_swap = match self {
@@ -239,7 +241,7 @@ impl TryInto<CandidateSwap> for Swap {
                 swap_id,
                 is_base_to_quote,
             },
-            _ => return Err(anyhow!("Swap {self:?} is not a valid candidate swap")),
+            _ => return Err(InvalidCandidateSwapError(self)),
         };
         Ok(candidate_swap)
     }


### PR DESCRIPTION
Moved from https://github.com/jup-ag/jupiter-amm-interface/pull/18

4 new errors for `trait Amm`, probably too wordy when implementing trait? we can use general `AmmError` but Json is uniq for fn from_keyed_account and AccountNotFound/Program are uniq for fn update :confused: 