### PR TITLE
Add Cube variant to enum in swap.rs

### DIFF
--- a/src/swap.rs
+++ b/src/swap.rs
@@ -14,6 +14,7 @@ pub enum Swap {
     Crema {
         a_to_b: bool,
     },
+    Cube,
     Mercurial,
     Aldrin {
         side: Side,


### PR DESCRIPTION
Adds a `Cube` variant to the `Swap` enum so the Cubic Pool DEX can be
  routed by Metis as a distinct venue (instead of riding the generic
  `TokenSwap` placeholder).

  ### About Cube
  Weighted constant-product AMM (Balancer V2 style) with virtual / actual
  balances, multi-token pools (2–10 tokens), and Token-2022 support.

  - Mainnet program id: `8iQtGj9mcUfFUGaiCpPy89swC3s8YTC8FhVZWfgeZhwu`
  - Source contracts: https://github.com/cubee-ee/contracts (private —
    happy to add Jupiter team as collaborators on request; just share
    GitHub usernames)

  ### Scope
  Single-line addition of a unit variant — kept alphabetically positioned
  next to similar generic variants. No behavioural change to existing
  variants.

  ### Companion PR
  The `Amm` trait implementation that emits this variant will be opened
  against `jup-ag/jupiter-amm-implementation` shortly. The adapter is
  already implemented, unit-tested (50 tests passing), and verified
  bit-identical to on-chain swap output against a local validator.
  Adapter source: https://github.com/cubee-ee/jup-inegration (private,
  same access process).

  Happy to address any feedback on naming or placement.
